### PR TITLE
Updated 1hive dao guide w. new apm repos & params

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -205,7 +205,7 @@ Before we install the projects app we can set a variable for the standard bounti
 
 `bounties=0x38f1886081759f7d352c28984908d04e8d2205a6`
 
-`dao --environment aragon:rinkeby install $onehive projects.aragonpm.eth --app-init-args $bounties $vault_allocations $token_honey`
+`dao --environment aragon:rinkeby install $onehive projects.aragonpm.eth --app-init-args $bounties $vault_allocations`
 
 Set variable:
 

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ And we can set the address to a variable
 
 Then we can install the address book app:
 
-`dao --environment aragon:rinkeby install $onehive tps-address-book.open.aragonpm.eth`
+`dao --environment aragon:rinkeby install $onehive address-book.aragonpm.eth`
 
 Set a variable for address book:
 
@@ -196,16 +196,16 @@ Set a variable for address book:
 
 Then we can set up the dot voting app linked to `Honey`:
 
-`dao --environment aragon:rinkeby install $onehive tps-dot-voting.open.aragonpm.eth --app-init-args $address_book $token_honey 500000000000000000 0 604800`
+`dao --environment aragon:rinkeby install $onehive dot-voting.aragonpm.eth --app-init-args $token_honey 500000000000000000 0 604800`
 
 Set a variable for dot voting
 `dot_voting=0x6d39A4151ebcaD63dde880518e110dE0942753a2`
 
 Before we install the projects app we can set a variable for the standard bounties contract on rinkeby:
 
-`bounties=0xcac024cb2ad5f22c3e92053b95c89f69442952d8`
+`bounties=0x38f1886081759f7d352c28984908d04e8d2205a6`
 
-`dao --environment aragon:rinkeby install $onehive tps-projects.open.aragonpm.eth --app-init-args $bounties $vault_allocations $token_honey`
+`dao --environment aragon:rinkeby install $onehive projects.aragonpm.eth --app-init-args $bounties $vault_allocations $token_honey`
 
 Set variable:
 
@@ -213,7 +213,7 @@ Set variable:
 
 Now we can install the allocations app:
 
-`dao --environment aragon:rinkeby install $onehive tps-allocations.open.aragonpm.eth --app-init-args $address_book $vault_allocations`
+`dao --environment aragon:rinkeby install $onehive allocations.aragonpm.eth --app-init-args $vault_allocations 2592000`
 
 Set variable:
 
@@ -226,6 +226,8 @@ Address Book:
 `dao --environment aragon:rinkeby acl create $onehive $address_book ADD_ENTRY_ROLE $voting_bee $voting_bee`
 
 `dao --environment aragon:rinkeby acl create $onehive $address_book REMOVE_ENTRY_ROLE $voting_bee $voting_bee`
+
+`dao --environment aragon:rinkeby acl create $onehive $address_book UPDATE_ENTRY_ROLE $voting_bee $voting_bee`
 
 Vault:
 
@@ -245,9 +247,9 @@ Projects:
 
 Dot voting:
 
-`dao --environment aragon:rinkeby acl create $onehive $dot_voting CREATE_VOTES_ROLE $manager_bee $voting_bee`
+`dao --environment aragon:rinkeby acl create $onehive $dot_voting ROLE_CREATE_VOTES $manager_bee $voting_bee`
 
-`dao --environment aragon:rinkeby acl create $onehive $dot_voting ADD_CANDIDATES_ROLE $manager_bee $voting_bee`
+`dao --environment aragon:rinkeby acl create $onehive $dot_voting ROLE_ADD_CANDIDATES $manager_bee $voting_bee`
 
 Allocations:
 
@@ -256,3 +258,5 @@ Allocations:
 `dao --environment aragon:rinkeby acl create $onehive $allocations CREATE_ALLOCATION_ROLE $dot_voting $voting_bee`
 
 `dao --environment aragon:rinkeby acl create $onehive $allocations EXECUTE_ALLOCATION_ROLE $manager_bee $voting_bee`
+
+`dao --environment aragon:rinkeby acl create $onehive $allocations CHANGE_BUDGETS_ROLE $voting_bee $voting_bee`


### PR DESCRIPTION
This PR includes:
* Changes to the apm package name to reflect the current deployment
* Changes to initialization params based on revised contracts

Please double check to make sure it works before merging this :)

Notes: 
* Since Address Book is no longer an initialization parameter for Dot Voting and Allocations, you may want to change which section it's in or remove it from your docs for now. Address Book won't be useful today since we rearchitected it and it has a dependency on [an aragon.js PR that still needs to be reviewed/merged](https://github.com/aragon/aragon.js/pull/391).
* Since Allocations app has budget controls now, you may want to connect it to the normal Finance vault for the DAO. It's still connected directly to vault.
* Projects is also still connected directly to the vault, so it cannot benefit from Finance's budget controls. This is something we are going to research the best way to handle in the next versions as we rethink budgeting in general in the coming months.
* There are still a couple minor frontend bugs that are a WIP, but we will be pushing patches every working day (or every other working day).

More details in a few announcement posts later today :) 

Thank you 1hive DAO for being our alpha testers 🐝 