### PR TITLE
Added that 1Hive is currently on xdai chain.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 
 # 1Hive Deployment Log
 
+Update: 1Hive is currently deployed on the xdai chain.
 1Hive is an Aragon organization, currently deployed to rinkeby.
 
 The following log describes the deployment process using the Aragon CLI. If your walking through this as a guide be sure to change the variables to correspond to addresses for your deployment.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 # 1Hive Deployment Log
 
-Update: 1Hive is currently deployed on the xdai chain.
+Update: 1Hive is currently deployed on the xdai chain.<br>
 1Hive is an Aragon organization, currently deployed to rinkeby.
 
 The following log describes the deployment process using the Aragon CLI. If your walking through this as a guide be sure to change the variables to correspond to addresses for your deployment.


### PR DESCRIPTION
I didn't see where we have a GitHub entry for the current DAO deployment or I would have included that as well.
It seems relevant to keep this up-to-date to avoid confusion.